### PR TITLE
Use the correct owner for my.cnf

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,11 +25,4 @@ include_attribute 'percona'
 default['percona-hardening']['user'] = 'mysql'
 default['percona-hardening']['service_name'] = 'mysql'
 
-case platform_family
-when 'rhel', 'fedora'
-  default['percona-hardening']['mysql-conf'] = '/etc/my.cnf'
-else
-  default['percona-hardening']['mysql-conf'] = '/etc/mysql/my.cnf'
-end
-
 default['percona-hardening']['hardening-conf'] = '/etc/mysql/conf.d/hardening.cnf'

--- a/recipes/hardening.rb
+++ b/recipes/hardening.rb
@@ -20,9 +20,9 @@
 #
 
 # protect my.cnf
-File node['percona-hardening']['mysql-conf'] do
+File node['percona']['main_config_file'] do
   mode '600'
-  owner 'root'
+  owner node['percona']['server']['username']
   group 'root'
 end
 


### PR DESCRIPTION
This should fix issue #1, also reuses the attribute for the file location from the percona cookbook.
